### PR TITLE
FIX: Add leading slash to load css files

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,8 +8,8 @@
     <link rel="icon" href="data:,">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous"> -->
-    <link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap_minty.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static '/css/bootstrap_minty.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static '/css/style.css' %}">
     <title>{% block title %} Developer Connect {% endblock %}</title>
 </head>
 <body>


### PR DESCRIPTION
Attempt to fix css loading problem of heroku by adding a leading slash to the css file names