### PR TITLE
FIX: Add ; after &laquo &raquo, modal moved in tr

### DIFF
--- a/app_home/templates/app_home/developer_overview.html
+++ b/app_home/templates/app_home/developer_overview.html
@@ -48,9 +48,9 @@
     <nav aria-label="Page navigation" class="small-margin">
         <ul class="pagination justify-content-center">
             {% if users.has_previous %}
-            <li class="page-item"><a class="page-link dark-text" href="?page={{ users.previous_page_number }}{{ href_filter }}">&laquo Previous</a></li>
+            <li class="page-item"><a class="page-link dark-text" href="?page={{ users.previous_page_number }}{{ href_filter }}">&laquo; Previous</a></li>
             {% else %}
-            <li class="page-item"><a class="page-link dark-text disabled" href="#">&laquo Previous</a></li>
+            <li class="page-item"><a class="page-link dark-text disabled" href="#">&laquo; Previous</a></li>
             {% endif %}
             {% for n in p_nums %}
             {% if users.number == forloop.counter %}
@@ -61,9 +61,9 @@
             {% endfor %}
             
             {% if users.has_next %}
-            <li class="page-item"><a class="page-link dark-text" href="?page= {{ users.next_page_number }}{{ href_filter }}">Next &raquo</a></li>
+            <li class="page-item"><a class="page-link dark-text" href="?page={{ users.next_page_number }}{{ href_filter }}">Next &raquo;</a></li>
             {% else %}
-            <li class="page-item"><a class="page-link dark-text disabled" href="#">Next &raquo</a></li>
+            <li class="page-item"><a class="page-link dark-text disabled" href="#">Next &raquo;</a></li>
             {% endif %}
         </ul>
     </nav>

--- a/app_home/templates/app_home/project_overview.html
+++ b/app_home/templates/app_home/project_overview.html
@@ -57,9 +57,9 @@
             <nav aria-label="Page navigation" class="small-margin">
                 <ul class="pagination justify-content-center">
                     {% if projects.has_previous %}
-                    <li class="page-item"><a class="page-link" href="?page={{ projects.previous_page_number }}{{ href_filter }}">&laquo Previous</a></li>
+                    <li class="page-item"><a class="page-link" href="?page={{ projects.previous_page_number }}{{ href_filter }}">&laquo; Previous</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link disabled" href="#">&laquo Previous</a></li>
+                    <li class="page-item"><a class="page-link disabled" href="#">&laquo; Previous</a></li>
                     {% endif %}
                     {% for n in p_nums %}
                     {% if projects.number == forloop.counter %}
@@ -70,9 +70,9 @@
                     {% endfor %}
                     
                     {% if projects.has_next %}
-                    <li class="page-item"><a class="page-link" href="?page= {{ projects.next_page_number }}{{ href_filter }}">Next &raquo</a></li>
+                    <li class="page-item"><a class="page-link" href="?page={{ projects.next_page_number }}{{ href_filter }}">Next &raquo;</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link disabled" href="#">Next &raquo</a></li>
+                    <li class="page-item"><a class="page-link disabled" href="#">Next &raquo;</a></li>
                     {% endif %}
                 </ul>
             </nav>

--- a/app_user/templates/app_user/messages.html
+++ b/app_user/templates/app_user/messages.html
@@ -14,7 +14,7 @@
             <h2>Recieved messages:</h2>
             <table class="table">
                 <tr>
-                    <th class="sm-hidden-table white-text">Picture</th>
+                    <th class="sm-hidden-table table-cell-text">Thumbnail</th>
                     <th class="table-cell-text">From</th>
                     <th class="table-cell-text">Title</th>
                     <th class="table-cell-text">Date recieved</th>
@@ -24,9 +24,9 @@
                 <tr>
                     <td class="align-middle sm-hidden">
                         <div class="square-container-small">
-                            <a href="{% url 'app_home:profile-detail-view' msg.user_sender.pk %}">
+                            <!-- <a href="{% url 'app_home:profile-detail-view' msg.user_sender.pk %}" class="square-img"> -->
                                 <img src="{{ msg.user_sender.profile_pic.values.0.profile_picture.url }}" alt="{{ msg.user_sender.username }}'s profile picture" class="square-img">
-                            </a>
+                            <!-- </a> -->
                         </div>
                     </td>
                     <td class="align-middle"><a href="{% url 'app_home:profile-detail-view' msg.user_sender.pk %}" class="table-cell-text">{{ msg.user_sender.username }}</a></td>
@@ -62,9 +62,9 @@
             <nav aria-label="Page navigation" class="small-margin">
                 <ul class="pagination justify-content-center">
                     {% if msgs.has_previous %}
-                    <li class="page-item"><a class="page-link dark-text" href="?page={{ msgs.previous_page_number }}">&laquo Previous</a></li>
+                    <li class="page-item"><a class="page-link dark-text" href="?page={{ msgs.previous_page_number }}">&laquo; Previous</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link dark-text disabled" href="#">&laquo Previous</a></li>
+                    <li class="page-item"><a class="page-link dark-text disabled" href="#">&laquo; Previous</a></li>
                     {% endif %}
                     {% for n in p_nums %}
                     {% if msgs.number == forloop.counter %}
@@ -75,9 +75,9 @@
                     {% endfor %}
                     
                     {% if msgs.has_next %}
-                    <li class="page-item"><a class="page-link dark-text" href="?page= {{ msgs.next_page_number }}">Next &raquo</a></li>
+                    <li class="page-item"><a class="page-link dark-text" href="?page= {{ msgs.next_page_number }}">Next &raquo;</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link dark-text disabled" href="#">Next &raquo</a></li>
+                    <li class="page-item"><a class="page-link dark-text disabled" href="#">Next &raquo;</a></li>
                     {% endif %}
                 </ul>
             </nav>

--- a/app_user/templates/app_user/sent_msgs.html
+++ b/app_user/templates/app_user/sent_msgs.html
@@ -14,7 +14,7 @@
             <h2>Sent messages:</h2>
             <table class="table">
                 <tr>
-                    <th class="sm-hidden-table white-text"></th>
+                    <th class="sm-hidden-table table-cell-text">Thumbnail</th>
                     <th class="table-cell-text">To</th>
                     <th class="table-cell-text">Title</th>
                     <th class="table-cell-text">Date sent</th>
@@ -35,30 +35,29 @@
                     <td class="align-middle small-text">{{ msg.sent_date }}</td>
                     <td class="align-middle"><a href="{% url 'app_user:edit_message' msg.pk %}" class="btn sm-hidden-table"><i class="fa-solid fa-pencil"></i></a></td>
                     <td class="align-middle"><button class="btn sm-hidden-table" style="color: #C63D17;" data-bs-toggle="modal" data-bs-target="#deleteMsgModal-{{ msg.id }}"><i class="fa-solid fa-trash-can"></i></button></td>
-                </tr>
-
-                <!-- Modal for delete message button -->
-                <!-- Modified from https://getbootstrap.com/docs/5.0/components/modal/ -->
-                <div class="modal fade" id="deleteMsgModal-{{ msg.id }}" tabindex="-1" role="dialog" aria-labelledby="deleteMsgModalLabel" aria-hidden="true">
-                    <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="deleteMsgModalLabel">Are you sure?</h5>
-                                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                                    <span id="close-pic-modal-span" aria-hidden="true">&times;</span>
-                                </button>
-                            </div>
-                            <div class="modal-body">
-                                <p>This action will delete the message for both you and the other user!</p>
-                                <p>This action is IRREVERSIBLE. Are you sure?</p>
-                            </div>
-                            <div class="modal-footer">
-                                <a href="" class="btn btn-primary" data-bs-dismiss="modal">Cancel</a>
-                            <a href="{% url 'app_user:delete_message' msg.id %}" class="btn btn-danger" id="confirm-pic-delete">Delete Message</a>
+                    <!-- Modal for delete message button -->
+                    <!-- Modified from https://getbootstrap.com/docs/5.0/components/modal/ -->
+                    <div class="modal fade" id="deleteMsgModal-{{ msg.id }}" tabindex="-1" role="dialog" aria-labelledby="deleteMsgModalLabel" aria-hidden="true">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="deleteMsgModalLabel">Are you sure?</h5>
+                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
+                                        <span id="close-pic-modal-span" aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                                <div class="modal-body">
+                                    <p>This action will delete the message for both you and the other user!</p>
+                                    <p>This action is IRREVERSIBLE. Are you sure?</p>
+                                </div>
+                                <div class="modal-footer">
+                                    <a href="" class="btn btn-primary" data-bs-dismiss="modal">Cancel</a>
+                                <a href="{% url 'app_user:delete_message' msg.id %}" class="btn btn-danger" id="confirm-pic-delete">Delete Message</a>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </tr>
                 {% endfor %}
             </table>
 
@@ -66,9 +65,9 @@
             <nav aria-label="Page navigation" class="small-margin">
                 <ul class="pagination justify-content-center">
                     {% if msgs.has_previous %}
-                    <li class="page-item"><a class="page-link dark-text" href="?page={{ msgs.previous_page_number }}">&laquo Previous</a></li>
+                    <li class="page-item"><a class="page-link dark-text" href="?page={{ msgs.previous_page_number }}">&laquo; Previous</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link dark-text disabled" href="#">&laquo Previous</a></li>
+                    <li class="page-item"><a class="page-link dark-text disabled" href="#">&laquo; Previous</a></li>
                     {% endif %}
                     {% for n in p_nums %}
                     {% if msgs.number == forloop.counter %}
@@ -79,9 +78,9 @@
                     {% endfor %}
                     
                     {% if msgs.has_next %}
-                    <li class="page-item"><a class="page-link dark-text" href="?page= {{ msgs.next_page_number }}">Next &raquo</a></li>
+                    <li class="page-item"><a class="page-link dark-text" href="?page={{ msgs.next_page_number }}">Next &raquo;</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link dark-text disabled" href="#">Next &raquo</a></li>
+                    <li class="page-item"><a class="page-link dark-text disabled" href="#">Next &raquo;</a></li>
                     {% endif %}
                 </ul>
             </nav>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -14,6 +14,7 @@
 
 body {
     color: #000;
+    padding: 0;
 }
 h3 {
     color: #000;
@@ -84,9 +85,9 @@ a {
     padding-top: 140px;
 }
 
-/* .navbar-dark .navbar-nav .nav-link {
-    color: rgba(255,255,255,0.8);
-} */
+.nav-x {
+    overflow-x: hidden;
+}
 
 .logo-container {
     /* background-color: #96E0CE; */
@@ -198,14 +199,14 @@ a {
 }
 
 .square-container-small {
-    display: none;
+    visibility: hidden;
 }
 .sm-hidden {
-    display:none;
+    visibility: hidden;
 }
 
 .sm-hidden-table {
-    display:none;
+    visibility: hidden;
 }
 @media screen and (min-width:768px){
     .square-container {
@@ -213,10 +214,10 @@ a {
         height: 400px;
     }
     .sm-hidden {
-        display:contents;
+        visibility: visible;
     }
     .sm-hidden-table{
-        display:table-cell;
+        visibility: visible;
     }
 }
 
@@ -230,9 +231,10 @@ a {
         margin: 0 auto;
     }
     .square-container-small {
-    width: 80px;
-    height: 80px;
-    margin: 5px auto;
+        visibility: visible;
+        width: 80px;
+        height: 80px;
+        margin: 5px auto;
     }
 }
 

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -18,7 +18,7 @@
         {% csrf_token %}
         {{ form|crispy }}
         {% if redirect_field_value %}
-        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
         {% endif %}
         <div class="col-md-12 text-center">
           <button type="submit" class="btn btn-primary small-margin-top">{% trans "Sign In" %}</button>

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -13,7 +13,7 @@
       <form method="post" action="{% url 'account_logout' %}">
         {% csrf_token %}
         {% if redirect_field_value %}
-        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
         {% endif %}
         <button type="submit" class="btn btn-primary">{% trans 'Sign Out' %}</button>
       </form>

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,16 +13,15 @@
     <!-- bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://res.cloudinary.com/djlm3llv5/raw/upload/v1678722262/static-files/f0enxww2f2ed5vj1pobg.css">
     <!-- custom css -->
-    <link rel="stylesheet" type="text/css" href="https://res.cloudinary.com/djlm3llv5/raw/upload/v1678739337/static-files/qfbeg4f1a5sw9jud7ryj.css">
+    <link rel="stylesheet" type="text/css" href="https://res.cloudinary.com/djlm3llv5/raw/upload/v1678784508/static-files/hrk19sbn9m8zq4p5wlwo.css">
     
     <title>{% block title %} Developer Connect {% endblock %}</title>
 </head>
-<body style="padding:0;">
-    <div class="min-vh-100 navbar-padding" style="overflow-x:hidden">
+<body">
+    <div class="min-vh-100 navbar-padding nav-x">
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky">
             <div class="container-fluid">
                 <a href="{% url 'app_home:index' %}" class="navbar-brand"><img src="https://res.cloudinary.com/djlm3llv5/image/upload/v1677952586/non%20square%20imgs/yydclfgb81lrk8m2hgnt.png" alt="The developer connect logo" style="height: 110px"></a>
-
                 <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
                 aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Following basic testing with https://validator.w3.org/ , some minor changes made including:
- add semicolon after &laquo and &raquo
- change `display` value to `visibility` so that table column can be hidden on smaller screen sizes
- remove trailing / at the end of `<input>` 